### PR TITLE
Fix platform scraping on video game collections

### DIFF
--- a/senscritiquescraper/utils/row_utils/row_utils.py
+++ b/senscritiquescraper/utils/row_utils/row_utils.py
@@ -208,8 +208,8 @@ def get_platforms(row: element.Tag) -> Optional[str]:
     """Get the supported platforms of a row."""
     try:
         platforms = (
-            row.find_all("p", {"class": "elco-baseline"})[1]
-            .text.split("sur")[-1]
+            row.find("span", {"class": "elco-gamesystem"})
+            .text
             .strip()
         )
     except Exception as e:

--- a/senscritiquescraper/utils/row_utils/row_utils.py
+++ b/senscritiquescraper/utils/row_utils/row_utils.py
@@ -205,14 +205,24 @@ def get_number_of_seasons(row: element.Tag) -> Optional[str]:
 
 
 def get_platforms(row: element.Tag) -> Optional[str]:
-    """Get the supported platforms of a row."""
+    """Get the supported platforms of a collection row."""
+    try:
+        platforms = row.find("span", {"class": "elco-gamesystem"}).text.strip()
+    except Exception as e:
+        logger.debug("Function get_platforms for row %s : %s", row, e)
+        platforms = None
+    return platforms
+
+
+def get_topchart_platforms(row: element.Tag) -> Optional[str]:
+    """Get the supported platforms of a topchart row."""
     try:
         platforms = (
-            row.find("span", {"class": "elco-gamesystem"})
-            .text
+            row.find_all("p", {"class": "elco-baseline"})[1]
+            .text.split("sur")[-1]
             .strip()
         )
     except Exception as e:
-        logger.debug("Function get_platforms for row %s : %s", row, e)
+        logger.debug("Function get_topchart_platforms for row %s : %s", row, e)
         platforms = None
     return platforms

--- a/senscritiquescraper/utils/row_utils/videogames_utils.py
+++ b/senscritiquescraper/utils/row_utils/videogames_utils.py
@@ -25,6 +25,31 @@ def get_videogames_infos_from_row(row: element.Tag) -> Dict:
     }
 
 
+def get_videogames_topchart_infos_from_row(row: element.Tag) -> Dict:
+    """Returns a dict containing infos for a videogame row.
+
+    Workaround to properly extract infos from a topchart.
+    Previously the platform function was compatible with both
+    collection and topchart, but as of early February 2022 the format
+    has changed between both.
+    """
+    return {
+        "Rank": row_utils.get_rank(row),
+        "Title": row_utils.get_title(row),
+        "URL": row_utils.get_url(row),
+        "Original Title": row_utils.get_original_title(row),
+        "Year": row_utils.get_year(row),
+        "Release Date": row_utils.get_baseline_0(row),
+        "Picture URL": row_utils.get_picture_url(row),
+        "Genre": row_utils.get_baseline_1(row),
+        "Developer": row_utils.get_producer(row),
+        "Platforms": row_utils.get_topchart_platforms(row),
+        "Description": row_utils.get_description(row),
+        "Average Rating": row_utils.get_average_rating(row),
+        "Number of Ratings": row_utils.get_number_of_ratings(row),
+    }
+
+
 def get_order_videogames_columns() -> List:
     """Returns the order of columns for videogames rows."""
     return [

--- a/senscritiquescraper/utils/topchart_utils.py
+++ b/senscritiquescraper/utils/topchart_utils.py
@@ -30,7 +30,9 @@ def get_topchart_infos(soup: BeautifulSoup, category: str) -> List[Dict]:
     elif category == "series":
         return [series_utils.get_series_infos_from_row(x) for x in rows]
     elif category == "jeuxvideo":
-        return [videogames_utils.get_videogames_infos_from_row(x) for x in rows]
+        return [
+            videogames_utils.get_videogames_topchart_infos_from_row(x) for x in rows
+        ]
     elif category == "livres":
         return [books_utils.get_books_infos_from_row(x) for x in rows]
     elif category == "bd":

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -34,7 +34,7 @@ def test_search_term_advanced_2():
 def test_search_term_position():
     search_term = "XTC"
     url_search = "https://www.senscritique.com/search?q=XTC"
-    url = "https://www.senscritique.com/album/Drums_and_Wires/6011492"
+    url = "https://www.senscritique.com/album/English_Settlement/1373616"
     soup = Senscritique.utils.get_soup(url_search)
 
     assert Senscritique.search_utils.get_search_url(search_term) == url_search

--- a/tests/tests_collection/test_collection_utils.py
+++ b/tests/tests_collection/test_collection_utils.py
@@ -129,6 +129,8 @@ def test_get_collection_infos(collection_soup):
         },
     ]
 
+    assert infos[3]["Platforms"] == "Wii U"
+
     for index, info in enumerate(infos):
         print(info)
         print(test_infos[index])

--- a/tests/tests_top/test_topchart_videogames.py
+++ b/tests/tests_top/test_topchart_videogames.py
@@ -47,7 +47,7 @@ def test_videogame_developer(topchart_row_videogame):
 
 
 def test_videogame_platforms(topchart_row_videogame):
-    platforms = row_utils.get_platforms(topchart_row_videogame)
+    platforms = row_utils.get_topchart_platforms(topchart_row_videogame)
     assert platforms == "Nintendo 64, GameCube, Wii, Wii U et Nintendo 3DS"
 
 

--- a/tests/tests_work/test_work_bd.py
+++ b/tests/tests_work/test_work_bd.py
@@ -7,7 +7,7 @@ def test_get_work_bd(work_object_bd):
 def test_rating_work_bd(work_object_bd):
     main_rating = work_object_bd.get_main_rating()
     assert isinstance(main_rating, str)
-    assert main_rating == "5.8"
+    assert main_rating == "5.7"
 
 
 def test_rating_details_work_bd(work_object_bd):

--- a/tests/tests_work/test_work_morceau.py
+++ b/tests/tests_work/test_work_morceau.py
@@ -31,7 +31,7 @@ def test_cover_url_work_morceau(work_object_morceau):
     assert isinstance(cover_url, str)
     assert (
         cover_url
-        == "https://media.senscritique.com/media/000000194665/160/Les_Copains_d_abord.jpg"
+        == "https://media.senscritique.com/media/000000194665/160/les_copains_dabord.jpg"
     )
 
 


### PR DESCRIPTION
The platform field on video game collections is now broken and showing the editor with a lot of unecessary whitespace. This PR fix the scraping to return the expected data.